### PR TITLE
Added telescope_type enum to radio_telescope table

### DIFF
--- a/src/main/kotlin/com/radiotelescope/repository/telescope/RadioTelescope.kt
+++ b/src/main/kotlin/com/radiotelescope/repository/telescope/RadioTelescope.kt
@@ -30,6 +30,10 @@ class RadioTelescope {
     @JoinColumn(name = "calibration_orientation_id")
     private lateinit var calibrationOrientation: Orientation
 
+    // This is a regular column because it is not a reference to a different table
+    @Column(name = "telescope_type", nullable = false)
+    private var telescopeType: TelescopeType = TelescopeType.NONE
+
     fun getId(): Long {
         return id
     }
@@ -44,5 +48,9 @@ class RadioTelescope {
     
     fun getCalibrationOrientation(): Orientation {
         return calibrationOrientation
+    }
+
+    fun getTelescopeType(): TelescopeType {
+        return telescopeType
     }
 }

--- a/src/main/kotlin/com/radiotelescope/repository/telescope/TelescopeType.kt
+++ b/src/main/kotlin/com/radiotelescope/repository/telescope/TelescopeType.kt
@@ -1,0 +1,7 @@
+package com.radiotelescope.repository.telescope
+
+enum class TelescopeType {
+    SLIP_RING,
+    HARD_STOP,
+    NONE
+}

--- a/src/main/resources/db/changelog/50-radio-telescope-add-telescope-type.sql
+++ b/src/main/resources/db/changelog/50-radio-telescope-add-telescope-type.sql
@@ -1,0 +1,8 @@
+-- liquibase formatted sql
+
+-- changeset pnelson:104
+ALTER TABLE radio_telescope
+ADD telescope_type ENUM('SLIP_RING', 'HARD_STOPS', 'NONE')
+DEFAULT 'NONE';
+
+-- rollback ALTER TABLE radio_telescope DROP COLUMN telescope_type;

--- a/src/main/resources/db/databaseChangeLog.xml
+++ b/src/main/resources/db/databaseChangeLog.xml
@@ -52,4 +52,5 @@
     <include file="classpath:/db/changelog/46-create-frontpage-picture.sql"/>
     <include file="classpath:/db/changelog/47-add-foreign-key-rf-data-appointment.sql"/>
     <include file="classpath:/db/changelog/48-user-profile-picture-approved.sql"/>
+    <include file="classpath:/db/changelog/50-radio-telescope-add-telescope-type.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
	Enum is non-nullable, and will allow us to make a telescope
	a slip ring or hard stop telescope. The default is none, though
	in production, that option will never be used unless in the event
	of an error.

Issue #54