### PR TITLE
Fixed bug that caused all the tests to fail

### DIFF
--- a/src/main/kotlin/com/radiotelescope/repository/telescope/RadioTelescope.kt
+++ b/src/main/kotlin/com/radiotelescope/repository/telescope/RadioTelescope.kt
@@ -31,7 +31,7 @@ class RadioTelescope {
     private lateinit var calibrationOrientation: Orientation
 
     // This is a regular column because it is not a reference to a different table
-    @Column(name = "telescope_type", nullable = false)
+    @Column(name = "telescope_type", nullable = true)
     private var telescopeType: TelescopeType = TelescopeType.NONE
 
     fun getId(): Long {


### PR DESCRIPTION
	The new TelescopeType enum must be nullable in order for tests
	using the previous schema to pass, otherwise the field must
	be modified for each and every one of those tests.

Issue #54